### PR TITLE
docs: add one-time USB buzzer setup step for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ chmod +x setup.sh
 ./setup.sh
 ```
 
+### Enabling USB buzzers on Linux (one-time)
+
+On Linux, USB buzzers need a one-time permission rule before any app can read them. Paste this **single line** into a terminal once (it asks for your password once, then prints nothing):
+
+```bash
+printf '%s\n' 'SUBSYSTEM=="usb", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="1000", MODE="0660", GROUP="plugdev", TAG+="uaccess"' 'KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="1000", MODE="0660", GROUP="plugdev", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/99-buzz.rules >/dev/null && sudo udevadm control --reload-rules && sudo udevadm trigger
+```
+
+That's it — your buzzers now work in the game. A few notes:
+
+- Run it **once per computer**. You can run it even before plugging the buzzers in.
+- If the buzzers were already plugged in, unplug and replug them once afterwards.
+- Without this, the buzzers show up as "not detected" (you can still play with the keyboard).
+
 ### Starting the setup script on Windows
 
 First, install these two free tools (if you don't have them already):


### PR DESCRIPTION
## What

Adds a short, copy-paste section to the README explaining how to enable USB Buzz! controllers on Linux.

## Why

On Linux, the USB Buzz! receiver (`054c:1000`) isn't readable by a normal user by default — the underlying HID library (used via `pybuzzers`) can't read the device descriptors or open it without elevated permissions. The result is that the game reports the buzzers as **"not detected"**, even though the kernel sees the device fine.

This is purely a permissions issue, fixed once with a udev rule that grants the logged-in user access (`uaccess` + `plugdev`). After that the game works without ever running as root.

## The added instructions

A single command users paste once per computer:

```bash
printf '%s\n' 'SUBSYSTEM=="usb", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="1000", MODE="0660", GROUP="plugdev", TAG+="uaccess"' 'KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="1000", MODE="0660", GROUP="plugdev", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/99-buzz.rules >/dev/null && sudo udevadm control --reload-rules && sudo udevadm trigger
```

It works whether or not the buzzers are currently plugged in (a udev rule applies to the device type, not a specific live connection).

## Scope

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)